### PR TITLE
Allowed workflow to be run without commit trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
 jobs:
   tag_release:
     if: ${{ github.event_name == 'push' }}
@@ -11,16 +13,22 @@ jobs:
     permissions:
       contents: write
     outputs:
-      version: ${{steps.tagging.outputs.new_tag}}
+      version: ${{steps.tagging.outputs.new_tag || steps.read_tag.outputs.tag}}
     steps:
       - uses: actions/checkout@v4
 
       - name: Bump version and push tag
+        if: ${{ github.event_name == 'push' }}
         id: tagging
         uses: anothrNick/github-tag-action@1.67.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch
+
+      - name: Read existing tag
+        if: ${{ github.event_name != 'push' }}
+        id: read_tag
+        run: echo "tag=`echo $(git describe --tags --abbrev=0)`\n" >> $GITHUB_OUTPUT
 
   publish_docker_image:
     needs: [tag_release]
@@ -57,6 +65,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get Time
+        id: time
+        uses: nanzm/get-time-action@master
+        with:
+          format: 'YYYY-MM-DDTHH:mm:ss'
+
       # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
@@ -66,6 +80,7 @@ jobs:
           context: .
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.tag_release.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.tag_release.outputs.version }}-${{ steps.time.outputs.time }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           push: true
 


### PR DESCRIPTION
- Can be triggered manually
- Either creates tag or uses the existing tag
- Gets timestamp
- Creates another image tag that includes the datetime